### PR TITLE
add ULTRA Fund to adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -255,6 +255,20 @@
 - date: 2024-10-22
   status: live
   entities:
+    - FundBridge Capital
+    - Wellington Management
+  products:
+    - ULTRA Fund
+#  tags:
+#    - Fund
+  chains:
+    - Ethereum
+#    - Arbitrum
+  sources:
+    - "https://libeara.com/libeara-partners-with-wellington-and-fundbridge-capital-to-launch-a-u-s-treasuries-fund-tokenised-on-public-blockchain/"
+- date: 2024-10-22
+  status: live
+  entities:
     - Buenos Aires
   products:
     - Digital Identity (QuarkID)

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -259,8 +259,6 @@
     - Wellington Management
   products:
     - ULTRA Fund
-#  tags:
-#    - Fund
   chains:
     - Ethereum
 #    - Arbitrum


### PR DESCRIPTION
`date`
 taken from SEO metadata
`<meta property="article:published_time" content="2024-10-22T03:10:09+00:00" />`

`entities`
Libeara is crypto native, so I did not include them

`context`
It's only for accredited investors and institutions, how should it be added? `For accredited investors` ,`For institutions` or perhaps both `For accredited investors and institutions`, idk, suggestions?

`tags`
 commented out (or maybe I should just not include them at all, wdyt?)

`chain`
Arbitrum is planned, but not live yet

