### PR TITLE
add MUFG's stablecoin to adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -625,6 +625,21 @@
     - Mainnet
   sources:
     - "https://www.wisdomtree.com/investments/digital-funds/money-market/wtgxx"
+- date: 2023-11-06
+  status: dev
+  entities:
+    - MUFG (Mitsubishi UFJ Financial Group) 
+  products:
+    - XJPY Stablecoin
+    - XUSD Stablecoin
+#  tags:
+#    - Stablecoin
+  chains:
+    - Mainnet
+#    - Polygon
+  sources:
+    - "https://progmat.co.jp/press/pdf/press231106_01.pdf"
+    - "https://prtimes.jp/main/html/rd/p/000000081.000036656.html"
 - date: 2023-10-02
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -632,6 +632,7 @@
   products:
     - XJPY Stablecoin
     - XUSD Stablecoin
+  context: For Business
 #  tags:
 #    - Stablecoin
   chains:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -66,6 +66,7 @@
 #     - 
 #   products:
 #     - 
+#   context: 
 #   tags:
 #     - 
 #   chains:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -634,8 +634,6 @@
     - XJPY Stablecoin
     - XUSD Stablecoin
   context: For Business
-#  tags:
-#    - Stablecoin
   chains:
     - Mainnet
 #    - Polygon


### PR DESCRIPTION
`date `
Used based on XJPY/XUSD announcement, but MUFG planned stablecoin usage back in 2/Jun/23, see prtimes.jp link. Feel free to update as you see fit

`entities`
all other entities involved are crypto native, so I left them out (Ginco, Progmat, Cumberland Global Limited, Bitbank Corporation, Melcoin, Inc., Datachain, TOKI FZCO)

`tag` 
Removed as advised

`chain`
Polygon commented out as I've seen it used on other entries