### PR TITLE
Fix grouped-by-entity.html

### DIFF
--- a/_includes/partials/grouped-by-entity.html
+++ b/_includes/partials/grouped-by-entity.html
@@ -1,82 +1,80 @@
-{%- assign entities = "" -%}
+{%- assign all_entities = "" -%}
 {%- for item in site.data.adoption -%}
   {%- for entity in item.entities -%}
-    {%- assign entities = entities | append: entity | append: "," -%}
+    {%- assign entity_stripped = entity | strip -%}
+    {%- assign all_entities = all_entities | append: "|||" | append: entity_stripped -%}
   {%- endfor -%}
 {%- endfor -%}
-{%- assign entities = entities | split: "," | uniq | sort -%}
+{%- assign entities = all_entities | split: "|||" | uniq | sort -%}
 {%- assign entity_count = entities | size -%}
-
 
 <select class="form-select mb-2" aria-label="Entity section select" onchange="selectAnchor(this)">
   <option selected>Select entity ({{entity_count}})</option>
   {%- for entity in entities -%}
-    {%- assign entity_id = entity | downcase | trim | replace: ' ', '-' -%}
-    <option value="entity-{{entity_id}}">{{entity}}</option>
+    {%- if entity != "" -%}
+      {%- assign entity_id = entity | downcase | trim | replace: ' ', '-' | replace: ',', '' -%}
+      <option value="entity-{{entity_id}}">{{entity}}</option>
+    {%- endif -%}
   {%- endfor -%}
 </select>
 
-
 {% include partials/legend.html %}
-
 
 {%- assign adoption = site.data.adoption | sort: "date" | reverse -%}
 {%- for entity in entities -%}
-  {%- assign entity_id = entity | downcase | trim | replace: ' ', '-' -%}
-  <div id="entity-{{entity_id}}" class="group-header">{{entity}}</div>
-  {%- for item in adoption -%}
-    {%- for item_entity in item.entities -%}
+  {%- if entity != "" -%}
+    {%- assign entity_id = entity | downcase | trim | replace: ' ', '-' | replace: ',', '' -%}
+    <div id="entity-{{entity_id}}" class="group-header">{{entity}}</div>
+    {%- for item in adoption -%}
+      {%- for item_entity in item.entities -%}
+        {%- assign item_entity_stripped = item_entity | strip -%}
+        {%- if entity == item_entity_stripped -%}
+          {%- assign date = item.date | date: "%b %d, %Y" -%}
 
-      {%- if entity == item_entity  -%}
-        {%- comment -%}
-          <!-- date formatting  https://learn.cloudcannon.com/jekyll/date-formatting/ -->
-        {%- endcomment -%}
-        {%- assign date = item.date | date: "%b %d, %Y" -%}
-
-        {%- assign status = "" -%}
-        {%- assign status_style = "" -%}
-        {%- if item.status != "live" -%}
-          {%- assign status = "[" | append: item.status | append: "] " -%}
-          {%- assign status_style = "status " | append: item.status -%}
-        {%- endif -%}
-
-        {%- assign entities = item.entities[0] -%}
-        {%- assign entity_count = item.entities | size -%}
-        {%- if entity_count > 1 -%}
-          {%- assign entities = item.entities | join: "/" -%}
-        {%- endif -%}
-
-        {%- assign products = item.products[0] -%}
-        {%- assign product_count = item.products | size -%}
-        {%- if product_count > 1 -%}
-          {%- assign products = item.products | join: ", " -%}
-        {%- endif -%}
-        {%- assign products = products | append: " " | append: item.context -%}
-
-        {%- capture chains -%}
-          {%- for chain in item.chains -%}
-            {%- assign filename = chain | downcase | trim | replace: ' ', '-' -%}
-            {%- if filename != "" -%}
-              <img class="network" src="/assets/img/networks/{{filename}}.webp" title="{{chain}}">
-            {%- endif -%}
-          {%- endfor -%}
-        {%- endcapture -%}
-
-        {%- assign source = item.sources[0] -%}
-
-        <div class="entry">
-          {%- if status_style != "" -%}
-            <span class="{{status_style}}"></span>
+          {%- assign status = "" -%}
+          {%- assign status_style = "" -%}
+          {%- if item.status != "live" -%}
+            {%- assign status = "[" | append: item.status | append: "] " -%}
+            {%- assign status_style = "status " | append: item.status -%}
           {%- endif -%}
-          <span class="date">{{date}}</span>
-          <a href="{{source}}" target="_blank">{{entities}} {{products | trim}}</a>
-          {{chains}}
-        </div>
-      {%- endif -%}
-    {%- endfor -%}
-  {%- endfor -%}
-{%- endfor -%}
 
+          {%- assign entities = item.entities[0] -%}
+          {%- assign entity_count = item.entities | size -%}
+          {%- if entity_count > 1 -%}
+            {%- assign entities = item.entities | join: "/" -%}
+          {%- endif -%}
+
+          {%- assign products = item.products[0] -%}
+          {%- assign product_count = item.products | size -%}
+          {%- if product_count > 1 -%}
+            {%- assign products = item.products | join: ", " -%}
+          {%- endif -%}
+          {%- assign products = products | append: " " | append: item.context -%}
+
+          {%- capture chains -%}
+            {%- for chain in item.chains -%}
+              {%- assign filename = chain | downcase | trim | replace: ' ', '-' -%}
+              {%- if filename != "" -%}
+                <img class="network" src="/assets/img/networks/{{filename}}.webp" title="{{chain}}">
+              {%- endif -%}
+            {%- endfor -%}
+          {%- endcapture -%}
+
+          {%- assign source = item.sources[0] -%}
+
+          <div class="entry">
+            {%- if status_style != "" -%}
+              <span class="{{status_style}}"></span>
+            {%- endif -%}
+            <span class="date">{{date}}</span>
+            <a href="{{source}}" target="_blank">{{entities}} {{products | trim}}</a>
+            {{chains}}
+          </div>
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endfor -%}
+  {%- endif -%}
+{%- endfor -%}
 
 <script type="text/javascript">
   function selectAnchor(select) {


### PR DESCRIPTION
Fix #7
Fix entities that contain comma(,) maintaining it as a single entity instead of splitting it into different entities

There were a few changes on how it handles: 

1. Entity Collection Method

Before: Use comma as delimiter which could cause issues with entity names containing commas
After: Use custom delimiter `|||` to avoid conflicts with entity name content
```diff
- {%- assign entities = entities | append: entity | append: "," -%}
+ {%- assign all_entities = all_entities | append: "|||" | append: entity_stripped -%}
```

2. Whitespace Handling

Add explicit stripping of whitespace for entity names and consistent whitespace handling throughout entity processing
```diff
+ {%- assign entity_stripped = entity | strip -%}
+ {%- assign item_entity_stripped = item_entity | strip -%}
```

3. Empty Entity Filtering

Add checks to prevent processing of empty entities, but we might not notice if entities end up empty again, feel free to remove
``` diff
+ {%- if entity != "" -%} 
```

4. Entity ID Generation

Add comma removal from entity IDs to prevent URL/anchor issues
```diff
- {%- assign entity_id = entity | downcase | trim | replace: ' ', '-' -%}
+ {%- assign entity_id = entity | downcase | trim | replace: ' ', '-' | replace: ',', '' -%}
```

Please review and test modifications to make sure it works properly on your end as well.
If issues are discovered, we can revert to the previous version of grouped-by-entity.html. 