### PR TITLE
add Nigeria's stablecoin cNGN to adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -80,6 +80,23 @@
 # Please enter in date order
 
 # 2025
+- date: 2025-02-05
+  status: live
+  entities:
+    - Central Bank of Nigeria (CBN)
+    - Wrapped CBDC
+  products:
+    - cNGN Stablecoin
+  context: For Individuals, For Business
+#  tags:
+#    - Stablecoin
+  chains:
+    - Mainnet
+    - Base
+#    - Polygon
+  sources:
+    - "https://businessday.ng/technology/article/what-cngn-nigerias-stablecoin-means-for-crypto-adoption/"
+    - "https://medium.com/@cngn_co/introducing-cngn-nigerias-first-compliant-stablecoin-pilot-caa2eb77ab18"
 - date: 2025-02-04
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -88,8 +88,6 @@
   products:
     - cNGN Stablecoin
   context: For Individuals, For Business
-#  tags:
-#    - Stablecoin
   chains:
     - Mainnet
     - Base


### PR DESCRIPTION
`date`
cNGN was live on 2/Feb per [twitter feed](https://x.com/cngn_co/status/1886060580441665928), but the first press release, dated from 5/Feb, I could find was a medium post on their twitter as well

First public comments by authorities I could find was on the 8/Feb on businessday

I decided to use the date from the medium press release. Feel free to edit as you see fit.

`entities`
Kindly review which entities should be present and edit as you see fit: 
cNGN is licenses by  Central Bank of Nigeria (CBN) and their SEC, but it is privately managed by crypto native Wrapped CBDC Ltd

See sources

`context`
It's for both `For Individuals`, `For Business`
Kindly confirm if it is the correct format to follow

`tags`
Removed tag as advised

`chains`
Polygon commented out following format from previous entries