### PR TITLE
add DWS' stablecoin adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -605,6 +605,18 @@
 
 
 # 2023
+- date: 2023-12-12
+  status: dev
+  entities:
+    - DWS
+    - Flow Traders
+  products:
+    - EUR-denominated stablecoin
+  chains:
+    - Mainnet
+  sources:
+    - "https://allunity.com/news/dws-flow-traders-and-galaxy-announce-the-intention-to-launch-allunity/"
+    - "https://blockworks.co/news/euro-denominated-ethereum-stablecoin-launch"
 - date: 2023-11-30
   status: live
   entities:


### PR DESCRIPTION
`date`
taken from press release

`status` 
dev, planned to release by Jun/25

`entities`
AllUnity is a JV involving DWS (owned by Deutsch Bank), Flow Traders and Galaxy Digital

AllUnity will be infrastructure provider facilitating on-chain payments, MiCAR compliant, EUR denominated stablecoin. 

I'm considering them as crypto native, if you disagree, let me know and I can update it

Omitted Galaxy Digital as they are crypto native as well,  

`product`
Stablecoin ticker is public yet

`chains`
Press release did not mention Ethereum itself, but multiple sources cite Ethereum and L2s, added blockworks with this reference