### PR TITLE
Add Lotte adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -399,6 +399,16 @@
     - Mainnet
   sources:
     - "https://blog.ens.domains/post/bringing-crypto-transfers-to-millions-with-paypal-and-venmo"
+- date: 2024-08-28
+  status: live
+  entities:
+    - Lotte
+  products:
+    - Caliverse
+  chains:
+    - Arbitrum
+  sources:
+    - "https://www.donga.com/news/It/article/all/20240828/126733132/1"
 - date: 2024-08-23
   status: live
   entities:


### PR DESCRIPTION
`date`
Date of when it was announced in WebX 2024 Asia

`sources`
this one seems to have flown under the radar in the west, so I added the most reputable source from South Korea I had.