### PR TITLE
add caceis adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -300,6 +300,17 @@
     - 
   sources:
     - "https://cointelegraph.com/news/stripe-acquires-stablecoin-platform-bridge-techcrunch-founder"
+- date: 2024-10-07
+  status: live
+  entities:
+    - CACEIS
+    - Twenty First Capital
+  products:
+    - UCITS Money Market Funds 
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.caceis.com/whats-new/press-releases/press-releases/article/caceis-records-client-subscriptions-in-spikos-tokenised-money-market-funds-on-public-blockchain/detail.html"
 - date: 2024-10-03
   status: live
   entities:


### PR DESCRIPTION
  `entities`
Omitted Spiko as they are blockchain native

  `products`
It started with 2 funds (SPKEUMM, SPKUSMM), plans for more. I opted to use the terminology of the source (UCITS MMF), which is a framework in the EU to facilitate crossborder fund trades