### PR TITLE
Add AUDD adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -711,6 +711,16 @@
   sources:
     - "https://www.ledgerinsights.com/mufg-drw-cumberland-stablecoin-crypto-settlement/"
     - "https://progmat.co.jp/press/pdf/press231106_01.pdf"
+- date: 2023-10-19
+  status: live
+  entities:
+    - Novatti
+  products:
+    - AUDD Stablecoin
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.audd.digital/audd-now-live-on-ethereum/"
 - date: 2023-10-02
   status: live
   entities:


### PR DESCRIPTION
`entities`
AUDD is issued by AUDC Pty Ltd, a crypto native company, which is a subsidiary of the Australian fintech Novatti Group Limited