### PR TITLE
Add Invesco adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -81,6 +81,18 @@
 # Please enter in date order
 
 # 2025
+- date: 2025-02-19
+  status: live
+  entities:
+    - Invesco
+  products:
+    - iSNR Fund
+  chains:
+    - Mainnet
+    - Arbitrum
+  sources:
+    - "https://insights.digift.sg/digift-collaborates-with-invesco-on-tokenized-solution/"
+    - "https://www.digift.sg/new-invest/detail?tokenCode=iSNR"
 - date: 2025-02-05
   status: live
   entities:


### PR DESCRIPTION
`entities`
Invesco partnered with DigiFT to release this fund. DigiFT is also involved with UBS' uMint Fund, I'm considering them as crypto native as well. Feel free to add them as you see fit

`sources`
I'm pretty sure I had originally seen the press release showing network and fund name information, but I think it might have been edited and I can't see it mentioned directly anymore, so I added below link  of the product page as source showing fund name and networks

https://www.digift.sg/new-invest/detail?tokenCode=iSNR

