### PR TITLE
Add Fazz adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -1238,6 +1238,20 @@
     - Mainnet
   sources:
     - "https://medium.com/arianee/enhance-your-breitling-luxury-watch-experience-with-arianee-1427e540538e"
+- date: 2020-10-05
+  status: live
+  entities:
+    - Fazz
+  products:
+    - XSGD Stablecoin
+    - XIDR Stablecoin
+    - XUSD Stablecoin
+  chains:
+    - Mainnet
+    - Arbitrum
+   # - Polygon
+  sources:
+    - "https://www.straitsx.com/blog-post/introducing-xsgd-the-singapore-dollar-backed-and-travel-rule1-compliant-stablecoin"
 - date: 2020-09-30
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -1250,7 +1250,7 @@
   chains:
     - Mainnet
     - Arbitrum
-   # - Polygon
+    # - Polygon
   sources:
     - "https://www.straitsx.com/blog-post/introducing-xsgd-the-singapore-dollar-backed-and-travel-rule1-compliant-stablecoin"
 - date: 2020-09-30

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -1243,9 +1243,10 @@
   entities:
     - Fazz
   products:
-    - XSGD Stablecoin
-    - XIDR Stablecoin
-    - XUSD Stablecoin
+    - XSGD
+    - XIDR
+    - XUSD
+  context: Stablecoins
   chains:
     - Mainnet
     - Arbitrum


### PR DESCRIPTION
`date`:
Dates from their blog posts need to be extracted from SEO metadata used by crawlers 

This is the public release date according to the `source`: 2020-10-05 

But the pilot started in Feb with the first contract deployment in  2020-03-25 

See:
https://etherscan.io/tx/0xf15487117214c774de6a99b9ca57551ead74b97f257716f246f9f61ab25c51a3

Which was first announced in 2020-03-26 here:
https://www.straitsx.com/blog-post/straitsx-2020-updates

I used the date of the public release, feel free to edit as you see fit

  `entities`
StraitsX, the issuer of the stablecoin, was originally a subsidiary of fintech Xfers, which merged with fintech Payfazz in 2021 to become Fazz 
https://techcrunch.com/2021/03/03/payfazz-invests-30m-in-xfers-as-the-two-southeast-asian-fintechs-form-fazz-financial-group/

I'm considering StraitsX as cryptonative, considering the portfolio of products they offer, and using the parent entity Fazz in this case 

Feel free to edit as you see fit 

 `products`
This announcement is only for XSGD from 2020. Nowadays they also have XIDR, launched in 2021, and XUSD, launched in 2024. Should I add these entries separately instead?

Right now the products is shown like this:
    - XSGD Stablecoin
    - XIDR Stablecoin
    - XUSD Stablecoin

Feel free to format it in a different way if it seems weird/repetitive. 

Let me know how to handle such cases in the future when there are multiple products of the same type (funds, stablecoins, etc) on the same entry

Other possible alternatives for this entry that I thought could be used is:
    - XSGD, XIDR, XUSD Stablecoin 

I guess it might depend on how it renders on the website. Feel free to adjust as needed

  `chains`
  Arbitrum was not in the original release and it only started being supported this year. Should I add a separate entry for the launch on Arbitrum?
  Commented out `# - Polygon`