### PR TITLE
Add Syz to adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -412,9 +412,9 @@
 - date: 2024-09-17
   status: live
   entities:
-    - Syz
+    - Bank Syz
   products:
-    - Art tokenization
+    - Art Tokenization
   chains:
     - Mainnet
   sources:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -409,6 +409,16 @@
     - 
   sources:
     - "https://cloud.google.com/blog/topics/financial-services/introducing-blockchain-rpc-service-for-web3-builders/"
+- date: 2024-09-17
+  status: live
+  entities:
+    - Syz
+  products:
+    - Art tokenization
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.taurushq.com/blog/taurus-collaborates-with-bank-syz-for-art-tokenization-and-trading-on-tdx-marketplace/"
 - date: 2024-09-12
   status: live
   entities:


### PR DESCRIPTION
 `products`
Quite telling the art they decided to tokenize is called `Dreamstime` 

If you read their posts, it is quite clear this is just the beginning: 
https://www.syzgroup.com/en/tokenization-syzart
https://blog.syzgroup.com/crypto-corner/are-we-ready-to-tokenise-the-syz-art-collection