### PR TITLE
Add SFV adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -351,7 +351,7 @@
   entities:
     - Lamborghini
   products:
-    -  Fast ForWorld NFT Platform
+    - Fast ForWorld NFT Platform
   chains:
     - Base
   sources:
@@ -804,6 +804,18 @@
     - Mainnet
   sources:
     - "https://oecd-opsi.org/innovations/openattestation/"
+- date: 2023-07-03
+  status: live
+  entities:
+    - Swiss Football Association
+    - Credit Suisse
+  products:
+    - Women's Football NFT Collection
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.football.ch/desktopdefault.aspx/tabid-2526/8544_read-266399/"
+    - "https://www.theblock.co/post/237557/credit-suisse-ethereum-nft-swiss-football-association"
 - date: 2023-06-09
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -808,7 +808,6 @@
   status: live
   entities:
     - Swiss Football Association
-    - Credit Suisse
   products:
     - Women's Football NFT Collection
   chains:


### PR DESCRIPTION
`entities`
I'm including Credit Suisse seen that they played a great part in it too: 
The digital NFT artworks was available to purchase via the digital assets function in the Credit Suisse CSX app

NFTs issued on Ethereum

“When we designed the offering, we consciously attempted to make it easy for the user to engage in the evolving NFT world,” Daniel Gorrera, head of digital assets Switzerland at Credit Suisse. “This project also paves the way for the innovative use of digital assets in new types of financing and servicing models. Within this space, Credit Suisse is well positioned for issuing parties that are looking for regulated partners.”

Source for above quote:
https://www.theblock.co/post/237557/credit-suisse-ethereum-nft-swiss-football-association