### PR TITLE
Fix EURCV adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -948,7 +948,7 @@
   entities:
     - Societe Generale
   products:
-    - EUR CoinVertible
+    - EURCV Stablecoin
   chains:
     - Mainnet
   sources:


### PR DESCRIPTION
`products`
Updated to `EURCV Stablecoin` to better represent the proposition of this product

If anyone tries to search for stablecoin on the site before, it would never come up