### PR TITLE
Add Fujitsu to adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -1535,7 +1535,7 @@
   entities:
     - Fujitsu
   products:
-    - Audit risk detection tool for smart contracts
+    - Smart Contract Auditing Software
   chains:
     - Mainnet
   sources:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -827,12 +827,12 @@
     - Fujitsu
     - Kanazawa Institute of Technology 
   products:
-    - AR app issues NFT for local event
+    - AR NFT Minting
   chains:
     - Mainnet
   sources:
-    - "https://www.fujitsu.com/global/about/resources/news/press-releases/2023/1002-01.html#footnote5"
-    - "https://www.fujitsu.com/jp/microsite/fujitsutransformationnews/2023-10-04/01/#anc-01"
+    - "https://www.fujitsu.com/global/about/resources/news/press-releases/2023/1002-01.html"
+    - "https://www.fujitsu.com/jp/microsite/fujitsutransformationnews/2023-10-04/01/"
 - date: 2023-10-02
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -824,6 +824,18 @@
 - date: 2023-10-02
   status: live
   entities:
+    - Fujitsu
+    - Kanazawa Institute of Technology 
+  products:
+    - AR app issues NFT for local event
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.fujitsu.com/global/about/resources/news/press-releases/2023/1002-01.html#footnote5"
+    - "https://www.fujitsu.com/jp/microsite/fujitsutransformationnews/2023-10-04/01/#anc-01"
+- date: 2023-10-02
+  status: live
+  entities:
     - UBS
     - SBI
   products:
@@ -1518,6 +1530,16 @@
     - Mainnet
   sources:
     - "https://archive.fo/cMRS2"
+- date: 2018-03-07
+  status: live
+  entities:
+    - Fujitsu
+  products:
+    - Audit risk detection tool for smart contracts
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.fujitsu.com/global/about/resources/news/press-releases/2018/0307-01.html"
 
 
 


### PR DESCRIPTION
 `products`
For 2023 entry, the sources in English did not provide a lot of details, even from Fujitsu themselves, so I had to add the second source in Japanese which has a lot more interesting details

Imagine POAP integrated with AR, plus benefits to future events when proving you have older POAPs
