### PR TITLE
Update Stripe adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -353,8 +353,13 @@
     - Stripe
   products:
     - Bridge
+  context: Stablecoins For Businesses
   chains:
-    - 
+    - Mainnet
+    - Arbitrum
+    - Base
+    - OP Mainnet
+    # - Polygon
   sources:
     - "https://cointelegraph.com/news/stripe-acquires-stablecoin-platform-bridge-techcrunch-founder"
 - date: 2024-10-07


### PR DESCRIPTION
As always, feel free to edit as you see fit

`context`
Added context to make it easier to search for stablecoins

`chains`
Currently supports issuance of their stablecoin (USDB and Custom Stablecoins) on Base, others are "coming soon". 

See https://apidocs.bridge.xyz/docs/stablecoin-issuance-v2

But Bridge's products are more than stablecoin issuance and they already support more chains too:

See https://apidocs.bridge.xyz/docs/blockchains
