### PR TITLE
Add Standard Chartered

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -220,6 +220,19 @@
     - # "using ZKsync technology"
   sources:
     - "https://cointelegraph.com/news/deutsche-bank-layer-2-blockchain-ethereum-zksync"
+- date: 2024-12-11
+  status: live
+  entities:
+    - Standard Chartered
+  products:
+    - USDG 
+    - USDL
+  context: Stablecoin Reserve Management
+  chains:
+    - Mainnet
+    - Arbitrum
+  sources:
+    - "https://www.paxos.com/newsroom/paxos-and-standard-chartered-lead-the-way-in-stablecoin-reserve-management"
 # - date: 2024-12-13 # was likely on DL3S, not Ethereum
 #   status: live
 #   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -220,6 +220,17 @@
     - # "using ZKsync technology"
   sources:
     - "https://cointelegraph.com/news/deutsche-bank-layer-2-blockchain-ethereum-zksync"
+# - date: 2024-12-13 # was likely on DL3S, not Ethereum
+#   status: live
+#   entities:
+#     - Societe Generale
+#     - Banque de France
+#   products:
+#     - Repo Transaction
+#   chains:
+#     - Mainnet
+#   sources:
+#     - "https://www.societegenerale.com/en/news/press-release/societe-generale-successfully-completed-first-repo-transaction-public-blockchain-banque-de-france"
 - date: 2024-12-11
   status: live
   entities:
@@ -233,17 +244,6 @@
     - Arbitrum
   sources:
     - "https://www.paxos.com/newsroom/paxos-and-standard-chartered-lead-the-way-in-stablecoin-reserve-management"
-# - date: 2024-12-13 # was likely on DL3S, not Ethereum
-#   status: live
-#   entities:
-#     - Societe Generale
-#     - Banque de France
-#   products:
-#     - Repo Transaction
-#   chains:
-#     - Mainnet
-#   sources:
-#     - "https://www.societegenerale.com/en/news/press-release/societe-generale-successfully-completed-first-repo-transaction-public-blockchain-banque-de-france"
 - date: 2024-11-25
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -236,9 +236,7 @@
   entities:
     - Standard Chartered
   products:
-    - USDG 
-    - USDL
-  context: Stablecoin Reserve Management
+    - Stablecoin Reserve Management
   chains:
     - Mainnet
     - Arbitrum


### PR DESCRIPTION
  `products`
Standard Chartered will provide cash management, trading, and custody services

I used "Stablecoin Reserve Management", as seen in the source title, for `context` so it looks similar to Mitsubishi's entry:

Mitsubishi UFJ - XJPY, XUSD Stablecoins For Businesses 
Standard Chartered - USDG, USDL Stablecoin Reserve Management

If used inappropriately, feel free to make necessary changes  

  `chains`
See docs
https://docs.paxos.com/stablecoin/usdg/mainnet > Ethereum
https://docs.paxos.com/stablecoin/usdl/mainnet > Ethereum+Arbitrum