### PR TITLE
Add Nubank

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -195,6 +195,16 @@
     - Mainnet
   sources:
     - "https://archive.md/UMwxE#selection-2107.0-2107.5"
+- date: 2024-01-14
+  status: live
+  entities:
+    - Nubank 
+  products:
+    - USDC treasury yield to customers
+  chains:
+    - Mainnet
+  sources:
+    - "https://international.nubank.com.br/consumers/nubank-expands-usdc-rewards-program-to-all-customers/"
 - date: 2025-01-08
   status: dev
   entities:
@@ -263,6 +273,16 @@
     - OP Mainnet
   sources:
     - "https://www.theblock.co/post/326288/blackrock-buidl-aptos-arbitrum-avalanche-optimism-polygon"
+- date: 2024-11-12
+  status: live
+  entities:
+    - Nubank
+  products:
+    - Onchain Trading 
+  chains:
+    - Mainnet
+  sources:
+    - "https://international.nubank.com.br/consumers/nubank-launches-cryptocurrency-swap-tool-in-its-app/"
 - date: 2024-11-07
   status: live
   entities:
@@ -581,6 +601,26 @@
     - Arbitrum
   sources:
     - "https://www.franklintempleton.com/press-releases/news-room/2024/franklin-templeton-enables-usdc-conversions-on-benji-investments-platform"
+- date: 2024-05-23
+  status: live
+  entities:
+    - Nubank 
+  products:
+    - External Transfers
+  chains:
+    - Mainnet
+  sources:
+    - "https://international.nubank.com.br/company/nubank-announces-sending-and-receiving-cryptocurrencies-directly-through-the-platform/"
+- date: 2024-05-23
+  status: live
+  entities:
+    - SCCF
+  products:
+    - Tokenized Debt Transaction
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.taurushq.com/blog/sccf-and-taurus-announce-successful-tokenization-of-end-to-end-trade-finance-transaction-on-tdx-marketplace/"
 - date: 2024-05-14
   status: live
   entities:
@@ -592,16 +632,6 @@
   sources:
     - "https://www.db.com/news/detail/20240514-deutsche-bank-joins-project-guardian-to-explore-asset-tokenization-applications"
     - "https://mementoblockchain.com/"
-- date: 2024-05-23
-  status: live
-  entities:
-    - SCCF
-  products:
-    - Tokenized Debt Transaction
-  chains:
-    - Mainnet
-  sources:
-    - "https://www.taurushq.com/blog/sccf-and-taurus-announce-successful-tokenization-of-end-to-end-trade-finance-transaction-on-tdx-marketplace/"
 - date: 2024-05-11
   status: live
   entities:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -200,7 +200,7 @@
   entities:
     - Nubank 
   products:
-    - USDC treasury yield to customers
+    - USDC Reward Program
   chains:
     - Mainnet
   sources:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -195,7 +195,7 @@
     - Mainnet
   sources:
     - "https://archive.md/UMwxE#selection-2107.0-2107.5"
-- date: 2024-01-14
+- date: 2025-01-14
   status: live
   entities:
     - Nubank 


### PR DESCRIPTION
Disclaimer: Friends aren't dumbasses that take pictures of screen. It's that as a banking app, it doesn't allow them to take screenshots. 

- date: 2025-01-14

  `products:`
    - USDC treasury yield to customers

This one is not clearly stated in the announcement nor in their webside directly, so I asked some local friends to try to find this information, and USDC is confirmed as available only for Ethereum and that the rewards is derived from the USDC rewards like Coinbase does

They offer 4% to customers and pocket the difference
![Onchain2](https://github.com/user-attachments/assets/178f9eea-7148-4f82-825a-df0bc7528610)

- date: 2024-11-12
  `products`
    - Onchain Trading 

Announcement and site do not mention many details, but locals also confirmed these swaps are on chain via Ethereum
See ![swaps2](https://github.com/user-attachments/assets/7a9e1615-1b4b-48c6-b5b9-043f48679d5e)


- date: 2024-05-23
  `products`
    - External Transfers

I added this one to follow along with Robinhood's entry, feel free to discard if deemed unnecessary

Announcement and site do not mention many details, but locals confirmed Ethereum mainnet too
Deposits and withdraws are supported for the same chains listed below
![Supported networks2](https://github.com/user-attachments/assets/e59030dd-cddf-491b-8a34-8c8f70571cf0)


fixed timeline order as well as I had messed it up with SCCF entry