### PR TITLE
Add Cuscal adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -908,8 +908,11 @@
   entities:
     - Cuscal
     - Mastercard
+    - Reserve Bank of Australia
+    - Digital Finance CRC
   products:
-    - Interoperable CBDC for Trusted Web3 Commerce
+    - Interoperable CBDC
+  context: For Trusted Web3 Commerce
   chains:
     - Mainnet
   sources:

--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -903,6 +903,17 @@
     - Mainnet
   sources:
     - "https://www.audd.digital/audd-now-live-on-ethereum/"
+- date: 2023-10-12
+  status: live
+  entities:
+    - Cuscal
+    - Mastercard
+  products:
+    - Interoperable CBDC for Trusted Web3 Commerce
+  chains:
+    - Mainnet
+  sources:
+    - "https://www.mastercard.com/news/ap/en/newsroom/press-releases/en/2023/mastercard-demonstrates-interoperable-cbdc-for-trusted-web3-commerce-in-australia-and-beyond/"
 - date: 2023-10-02
   status: live
   entities:
@@ -936,7 +947,7 @@
     - Mainnet
   sources:
     - "https://usa.visa.com/about-visa/newsroom/press-releases.releaseId.19881.html"
-- date: 2024-09-04
+- date: 2023-09-04
   status: live
   entities:
     - Palau


### PR DESCRIPTION
`date`

I'm using the date Mastercard confirmed the pilot was a success, but it started in 1/Mar/23 as seen here:

https://dfcrc.com.au/2023/03/01/interoperable-cbdc-for-trusted-web3-commerce/

https://x.com/DigiFinanceCRC/status/1631058842673987584

Feel free to change as needed

+ 

Fix date on Palau entry

`entities`
Should I have included Reserve Bank of Australia (RBA) and the Digital Finance Cooperative Research Centre (DFCRC)?