### PR TITLE
Add Seven Deadly Sins adoption.yml

### DIFF
--- a/_data/adoption.yml
+++ b/_data/adoption.yml
@@ -96,6 +96,17 @@
     - 
   sources:
     - "https://www.coindesk.com/business/2025/04/02/fidelity-lets-investors-directly-invest-in-crypto-through-new-retirement-plan"
+- date: 2025-03-25
+  status: live
+  entities:
+    - The Seven Deadly Sins anime
+  products:
+    - Official NFT collection 
+  chains:
+    - Soneium
+  sources:
+    - "https://prtimes.jp/main/html/rd/p/000000013.000135510.html"
+    - "https://www.animenewsnetwork.com/press-release/2025-03-25/yoake-partners-with-opensea-to-bring-iconic-multimedia-franchise-the-seven-deadly-sins-on-soneium/.222843"
 - date: 2025-03-24
   status: live
   entities:


### PR DESCRIPTION
  `entities`
I was going to use `YOAKE entertainment`, which is a joint venture between four leading entertainment companies in Japan (ASOBISYSTEM, TWIN PLANET, Y&N Brothers, and W TOKYO) 

But looking at their website now, it seems they might be considered crypto native. They seem to be a bridge between the entertainment space in Japan and crypto, specially if you look at their other news

https://yoake-entertainment.jp/en/#c-news

Soneium+Yoake are cooking

I'll wait for your feedback before adding other entries related to them

Soneium BD team are big with IPs, there's a bunch of stuff going on there